### PR TITLE
fix(config): copy turbo.json for monorepo docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM node:20.19.0-alpine AS builder
 WORKDIR /app
 COPY backend/package.json backend/package-lock.json ./
+COPY turbo.json ./
 RUN npm install
 COPY backend/. ./
 RUN npm run build  # Ensure this outputs to /app/dist


### PR DESCRIPTION
ensure turbo.json is present for turborepo builds in docker context unblocks local and render deploys