### PR TITLE
fix(backend): ensure server starts correctly with render and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 10000) + '/health', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"
 
 # Start the backend
-CMD ["node", "server.js"]
+CMD ["node", "start.js"]

--- a/backend/start.js
+++ b/backend/start.js
@@ -4,14 +4,8 @@ const app = createApp();
 
 const PORT = process.env.PORT || 10000;
 
-const server = app.listen(PORT, () => {
-  console.log(`🚀 CanAI Backend Server running on port ${PORT}`);
-  console.log(`📍 Environment: ${process.env.NODE_ENV || 'development'}`);
-  console.log(`🔒 Security headers: enabled`);
-  console.log(`🌐 CORS: configured`);
-  console.log(
-    `📝 Logging: ${process.env.NODE_ENV === 'production' ? 'combined' : 'dev'}`
-  );
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`Server running on port ${PORT}`);
 });
 
 process.on('SIGTERM', () => {

--- a/scripts/Show-FilteredTree.ps1
+++ b/scripts/Show-FilteredTree.ps1
@@ -1,0 +1,54 @@
+# Show-FilteredTree.ps1
+#
+# Usage:
+#   . ./Show-FilteredTree.ps1   # Import the function into your session
+#   Show-FilteredTree           # Run in current directory
+#   Show-FilteredTree -Path "C:\Backups\canai-build" -Depth 3
+#
+# Excludes:
+#   - All task_*.txt files
+#   - All *.bak and *.log files
+#   - tsconfig.tsbuildinfo, yarn-error.log
+# Summarizes:
+#   - node_modules, dist, build, coverage as [dir - summarized]
+
+function Show-FilteredTree {
+    param(
+        [string]$Path = ".",
+        [int]$Depth = 99,
+        [string[]]$ExcludePatterns = @("task_*.txt", "*.bak", "*.log", "tsconfig.tsbuildinfo", "yarn-error.log"),
+        [string[]]$SummarizeDirs = @("node_modules", "dist", "build", "coverage")
+    )
+
+    function Show-Tree ($CurrentPath, $Prefix = "", $Level = 0) {
+        if ($Level -ge $Depth) { return }
+        $items = Get-ChildItem -LiteralPath $CurrentPath -Force | Sort-Object -Property PSIsContainer, Name
+        $count = $items.Count
+        for ($i = 0; $i -lt $count; $i++) {
+            $item = $items[$i]
+            $isLast = ($i -eq $count - 1)
+            $connector = if ($isLast) { "└── " } else { "├── " }
+            $newPrefix = $Prefix + (if ($isLast) { "    " } else { "│   " })
+
+            # Exclude files by pattern
+            $exclude = $false
+            foreach ($pattern in $ExcludePatterns) {
+                if ($item.Name -like $pattern) { $exclude = $true; break }
+            }
+            if ($exclude) { continue }
+
+            # Summarize certain directories
+            if ($item.PSIsContainer -and $SummarizeDirs -contains $item.Name) {
+                Write-Host "$Prefix$connector[$($item.Name) - summarized]"
+                continue
+            }
+
+            Write-Host "$Prefix$connector$item"
+            if ($item.PSIsContainer) {
+                Show-Tree -CurrentPath $item.FullName -Prefix $newPrefix -Level ($Level + 1)
+            }
+        }
+    }
+
+    Show-Tree -CurrentPath (Resolve-Path $Path) -Prefix "" -Level 0
+}


### PR DESCRIPTION
- change Dockerfile CMD to use start.js for proper server startup
- ensure start.js binds to process.env.PORT and 0.0.0.0 for Docker/Render compatibility
- confirm healthcheck uses /health endpoint for render compliance
- prepares backend for successful container health and deployment

refs: render deployment, docker local testing, healthcheck improvements