### PR TITLE
fix(backend): esm export for preview_spark.js

### DIFF
--- a/backend/middleware/sanitize.js
+++ b/backend/middleware/sanitize.js
@@ -4,13 +4,11 @@
 
 import createDOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
-import { createRequire } from 'module';
 let _logger;
 try {
-  const require = createRequire(import.meta.url);
-  _logger =
-    require('../api/src/Shared/Logger').default ||
-    require('../api/src/Shared/Logger');
+  // ESM dynamic import for Logger
+  const loggerModule = await import('../api/src/Shared/Logger.js');
+  _logger = loggerModule.default || loggerModule;
 } catch (err) {
   _logger = console;
 }
@@ -175,7 +173,7 @@ export function sanitizeWithSchema(data, schema, path = '') {
           appliedSchema = schema[String(idx)];
         } else if (Object.prototype.hasOwnProperty.call(schema, '0')) {
           appliedSchema = schema['0'];
-        } else if (schema.sanitize || schema.mode) {
+        } else if (appliedSchema.sanitize || appliedSchema.mode) {
           appliedSchema = schema;
         }
       }

--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -1,15 +1,13 @@
 import Joi from 'joi';
 import { sanitize } from './sanitize.js';
 import { sanitizeWithSchema, ValidationError } from './sanitize.js';
-import { createRequire } from 'module';
 import posthog, { safeCapture } from '../services/posthog.js';
-const Sentry = require('../services/instrument.js');
+import * as Sentry from '../services/instrument.js';
 let _logger;
 try {
-  const require = createRequire(import.meta.url);
-  _logger =
-    require('../api/src/Shared/Logger').default ||
-    require('../api/src/Shared/Logger');
+  // ESM dynamic import for Logger
+  const loggerModule = await import('../api/src/Shared/Logger.js');
+  _logger = loggerModule.default || loggerModule;
 } catch (err) {
   _logger = console;
 }

--- a/backend/prompts/preview_spark.js
+++ b/backend/prompts/preview_spark.js
@@ -4,7 +4,7 @@
  * - Tagline: 10–20 characters, inspiring, trust-building
  * - Output: JSON { "title": "...", "tagline": "..." }
  */
-module.exports = ({ businessType, tone }) => `
+const previewSpark = ({ businessType, tone }) => `
 You are an expert business copywriter for CanAI, a platform that creates emotionally resonant, curiosity-driven concept names ("sparks") for businesses.
 
 Generate ONE preview Spark for a business of type "${businessType}" with a "${tone}" tone.
@@ -21,3 +21,5 @@ Respond ONLY with a JSON object:
   "tagline": "..."
 }
 `;
+
+export default previewSpark;

--- a/docs/messages-api-implementation-plan.md
+++ b/docs/messages-api-implementation-plan.md
@@ -4,7 +4,9 @@
 
 ## Purpose & Strategic Goals
 
-This document outlines the implementation plan for the CanAI Platform's **Messages API** and supporting data model. It is designed to:
+This document outlines the implementation plan for the CanAI Platform's **Messages API** and
+supporting data model. It is designed to:
+
 - Align with PRD Section 6.1 and the 9-stage user journey (F1–F9)
 - Support both current trust indicator messaging and future user/system messaging features
 - Ensure security, compliance, and extensibility
@@ -15,6 +17,7 @@ This document outlines the implementation plan for the CanAI Platform's **Messag
 ## TaskMaster Tasks & Deliverables
 
 ### **Current Tasks**
+
 - **Task 13.1:** Design and implement message data model with database schema
   - Create the `messages` table in Supabase with all required fields
   - Implement migration scripts and indexes
@@ -26,6 +29,7 @@ This document outlines the implementation plan for the CanAI Platform's **Messag
   - Add comprehensive tests and documentation
 
 ### **Key Deliverables**
+
 - New `messages` table migration (Supabase SQL)
 - Joi validation schema for message objects
 - API contract documentation (input/output, error structure)
@@ -37,24 +41,29 @@ This document outlines the implementation plan for the CanAI Platform's **Messag
 
 ## PRD & User Journey Alignment
 
-- **PRD Section 6.1:** Requires robust messaging infrastructure for trust indicators and future user/system messages
-- **API Contract:** Supports rich message objects (id, text, author, type, timestamps, emotional tone, trust score, etc.)
+- **PRD Section 6.1:** Requires robust messaging infrastructure for trust indicators and future
+  user/system messages
+- **API Contract:** Supports rich message objects (id, text, author, type, timestamps, emotional
+  tone, trust score, etc.)
 - **Security & Compliance:** Enforces RLS, validation, sanitization, and GDPR/CCPA data retention
 - **Performance:** Indexed for <200ms API responses, 5-min cache TTL
-- **Extensibility:** Schema supports testimonials, trust indicators, user-to-user, and system notifications
+- **Extensibility:** Schema supports testimonials, trust indicators, user-to-user, and system
+  notifications
 
 ---
 
 ## Implementation Plan (Strategic & Future-Proofed)
 
 ### 1. **Schema & Migration**
+
 - Design `messages` table with fields:
   - `id` (UUID, PK)
   - `text` (TEXT, required)
   - `author` (TEXT, optional)
   - `sender_id` (UUID, FK to users, nullable)
   - `recipient_id` (UUID, FK to users, nullable)
-  - `type` (ENUM: 'testimonial', 'trust_indicator', 'sample_preview', 'success_story', 'user_message', 'system_notification')
+  - `type` (ENUM: 'testimonial', 'trust_indicator', 'sample_preview', 'success_story',
+    'user_message', 'system_notification')
   - `emotional_tone` (ENUM: 'warm', 'bold', 'optimistic', 'inspirational', etc.)
   - `trust_score_context` (NUMERIC, optional)
   - `location` (TEXT, optional)
@@ -66,12 +75,14 @@ This document outlines the implementation plan for the CanAI Platform's **Messag
 - Document migration in `/backend/supabase/migrations/`
 
 ### 2. **Validation & Sanitization**
+
 - Define Joi schema for all message fields
 - Integrate with centralized validation and sanitization middleware (Joi + DOMPurify)
 - Ensure all string fields are sanitized for XSS and injection
 - Follow error handling and logging best practices (see docs/task-9-input-validation-middleware.md)
 
 ### 3. **API Contract & Endpoints**
+
 - Document input/output schemas for GET/POST /v1/messages
 - Implement endpoints in `backend/routes/messages.js`
 - Ensure response structure matches contract in `docs/api-contract-specification.md`
@@ -79,18 +90,21 @@ This document outlines the implementation plan for the CanAI Platform's **Messag
 - Implement comprehensive error handling and rate limiting
 
 ### 4. **Testing & Documentation**
+
 - Create/extend test plan for all endpoints, including edge cases and malicious payloads
 - Use Vitest for integration and unit tests
 - Assert on validation, sanitization, analytics, and error handling
 - Update this document and related docs after each major step
 
 ### 5. **Security, Compliance, & Observability**
+
 - Enforce RLS and access policies in Supabase
 - Log all validation and error events to PostHog/Sentry
 - Ensure GDPR/CCPA compliance (24-month purge, consent tracking)
 - Monitor cache hit/miss, API latency, and error rates
 
 ### 6. **Future-Proofing & Extensibility**
+
 - Design schema to support:
   - User-to-user and system messages
   - Rich content (attachments, reactions, threading)
@@ -101,6 +115,7 @@ This document outlines the implementation plan for the CanAI Platform's **Messag
 ---
 
 ## References & Related Documentation
+
 - PRD.md (Section 6.1, 8.4, 12)
 - docs/api-contract-specification.md
 - docs/data-model-schema.md

--- a/docs/task-11-retry-middleware-implementation-plan.md
+++ b/docs/task-11-retry-middleware-implementation-plan.md
@@ -4,12 +4,16 @@
 
 ## Purpose & PRD Alignment
 
-This document provides a concrete, actionable, and defensive implementation plan for Task 11: **Create Retry Middleware with Exponential Backoff**. It is designed to:
-- Align with PRD requirements for API reliability, resilience, and observability (see PRD Sections 6, 7, 8, 12, 16)
+This document provides a concrete, actionable, and defensive implementation plan for Task 11:
+**Create Retry Middleware with Exponential Backoff**. It is designed to:
+
+- Align with PRD requirements for API reliability, resilience, and observability (see PRD Sections
+  6, 7, 8, 12, 16)
 - Support current and future needs for robust error handling and external API reliability
 - Ensure security, compliance, and extensibility
 - Serve as a living reference for TaskMaster Task 11 and all related reliability work
-- **Reference PRD metrics:** e.g., “<1% failed requests due to transient errors”, “Mean time to recovery < 1 min”
+- **Reference PRD metrics:** e.g., “<1% failed requests due to transient errors”, “Mean time to
+  recovery < 1 min”
 - **Map to user journey stages:** F4 (Purchase Flow), F7 (Deliverable), F9 (Feedback)
 
 ---
@@ -17,6 +21,7 @@ This document provides a concrete, actionable, and defensive implementation plan
 ## TaskMaster Tasks & Deliverables
 
 ### **Current Tasks**
+
 - **Task 11:** Create Retry Middleware (exponential backoff, circuit breaker, logging)
   - **11.1:** Implement retry logic with exponential backoff
   - **11.2:** Add circuit breaker pattern for persistent failures
@@ -24,6 +29,7 @@ This document provides a concrete, actionable, and defensive implementation plan
   - **11.4:** **Create and maintain `retry-middleware-test-plan.md` and test skeleton subtask**
 
 ### **Future-Proofing**
+
 - Design for easy extension to other endpoints/services
 - Modularize for per-endpoint and per-external-service strategies
 - Integrate with observability (Sentry, PostHog)
@@ -49,7 +55,8 @@ This document provides a concrete, actionable, and defensive implementation plan
   - Encapsulate all retry and circuit breaker logic
   - Configurable max attempts, initial delay, backoff factor, and circuit breaker thresholds
   - **All config must be injectable for testability and future multi-tenant support**
-  - **Separation of concerns:** retry logic, circuit breaker, and logging must be independently testable
+  - **Separation of concerns:** retry logic, circuit breaker, and logging must be independently
+    testable
 - **Integration:** Apply middleware to routes/services that call external APIs
 - **Observability:** Log all retry/circuit breaker events to Sentry/PostHog
 - **Error Handling:** Provide user-friendly error messages and status codes
@@ -59,9 +66,11 @@ This document provides a concrete, actionable, and defensive implementation plan
 ## Implementation Phases & Phase Gates
 
 ### 1. Retry Logic with Exponential Backoff
+
 > **Phase Gate:** Middleware exposes retry logic with configurable attempts, delay, and backoff.
 
 **Success Criteria:**
+
 - Can wrap async functions and retry on failure
 - Delay increases exponentially between attempts
 - Respects max attempts and aborts on success
@@ -70,6 +79,7 @@ This document provides a concrete, actionable, and defensive implementation plan
 - **Classify errors and only retry on whitelisted error types (network, HTTP, etc.)**
 
 **Example:**
+
 ```ts
 // middleware/retry.ts
 export async function retryWithBackoff(fn, options = {}) {
@@ -79,7 +89,7 @@ export async function retryWithBackoff(fn, options = {}) {
     backoffFactor = 2,
     jitter = 0.2, // 20% jitter
     abortSignal,
-    shouldRetry = (err) => true, // error classifier
+    shouldRetry = err => true, // error classifier
     onRetry = () => {},
   } = options;
   let attempt = 0;
@@ -97,10 +107,11 @@ export async function retryWithBackoff(fn, options = {}) {
       if (abortSignal?.aborted) throw new Error('Retry aborted');
       await new Promise((res, rej) => {
         const timeout = setTimeout(res, finalDelay);
-        if (abortSignal) abortSignal.addEventListener('abort', () => {
-          clearTimeout(timeout);
-          rej(new Error('Retry aborted'));
-        });
+        if (abortSignal)
+          abortSignal.addEventListener('abort', () => {
+            clearTimeout(timeout);
+            rej(new Error('Retry aborted'));
+          });
       });
       delay *= backoffFactor;
     }
@@ -111,9 +122,11 @@ export async function retryWithBackoff(fn, options = {}) {
 ---
 
 ### 2. Circuit Breaker Pattern
+
 > **Phase Gate:** Circuit breaker logic is implemented to halt retries on persistent failures.
 
 **Success Criteria:**
+
 - Circuit breaker opens after N consecutive failures
 - Remains open for a cooldown period before allowing retries
 - Logs state transitions (open, half-open, closed)
@@ -122,6 +135,7 @@ export async function retryWithBackoff(fn, options = {}) {
 - **Alert if circuit remains open > threshold (e.g., 5 min)**
 
 **Example:**
+
 ```ts
 // middleware/circuitBreaker.ts
 class CircuitBreaker {
@@ -164,9 +178,11 @@ class CircuitBreaker {
 ---
 
 ### 3. Logging & Observability
+
 > **Phase Gate:** All retry and circuit breaker events are logged to Sentry/PostHog.
 
 **Success Criteria:**
+
 - Retry attempts, failures, and circuit breaker state changes are logged
 - Analytics events are sent for monitoring and alerting
 - **All logs must include correlation IDs for traceability**
@@ -174,6 +190,7 @@ class CircuitBreaker {
 - **Dashboards/alerts for retry/circuit metrics must be in place**
 
 **Example:**
+
 ```ts
 // In retry/circuit breaker logic
 import * as Sentry from '../services/instrument.js';
@@ -185,9 +202,11 @@ posthog.capture('retry_attempt', { attempt, error: err.message, correlationId })
 ---
 
 ### 4. Error Handling & User Experience
+
 > **Phase Gate:** User-facing errors are clear, actionable, and do not leak sensitive info.
 
 **Success Criteria:**
+
 - On persistent failure, return a user-friendly error message
 - No stack traces or sensitive info in responses
 - **All user-facing errors must have error codes and be documented**
@@ -196,9 +215,12 @@ posthog.capture('retry_attempt', { attempt, error: err.message, correlationId })
 ---
 
 ### 5. Testing & Validation
-> **Phase Gate:** Vitest test suite covers all retry, backoff, and circuit breaker logic and edge cases.
+
+> **Phase Gate:** Vitest test suite covers all retry, backoff, and circuit breaker logic and edge
+> cases.
 
 **Success Criteria:**
+
 - All retry/circuit breaker operations are tested (success, failure, open/close transitions)
 - Edge cases: max attempts, cooldown, rapid failures, partial successes, clock skew
 - Test logs and metrics for retry/circuit breaker events
@@ -210,6 +232,7 @@ posthog.capture('retry_attempt', { attempt, error: err.message, correlationId })
 ---
 
 ## Defensive Rollback & Iteration Plan
+
 - After each change, run affected and full test suite
 - If regression, revert last change and isolate issue
 - Log all findings and lessons learned in TaskMaster and docs
@@ -219,6 +242,7 @@ posthog.capture('retry_attempt', { attempt, error: err.message, correlationId })
 ---
 
 ## Acceptance Criteria & Checklist
+
 - [ ] Retry logic implemented and tested
 - [ ] Circuit breaker logic present and tested
 - [ ] Logging and analytics integrated
@@ -232,6 +256,7 @@ posthog.capture('retry_attempt', { attempt, error: err.message, correlationId })
 ---
 
 ## References & Best Practices
+
 - PRD.md (Sections 6, 7, 8, 12, 16; see metrics and SLOs)
 - [CanAI Structure Rules](../.cursor/rules/canai-structure-rules.mdc)
 - [Task 9 Input Validation Plan](task-9-input-validation-middleware.md)

--- a/docs/task-12-node-cache-service-implementation-plan.md
+++ b/docs/task-12-node-cache-service-implementation-plan.md
@@ -4,8 +4,11 @@
 
 ## Purpose & PRD Alignment
 
-This document provides a concrete, actionable, and defensive implementation plan for Task 12: **Setup Node-Cache Service**. It is designed to:
-- Align with PRD requirements for API performance, resilience, and observability (see PRD Sections 6, 7, 8, 12, 16)
+This document provides a concrete, actionable, and defensive implementation plan for Task 12:
+**Setup Node-Cache Service**. It is designed to:
+
+- Align with PRD requirements for API performance, resilience, and observability (see PRD Sections
+  6, 7, 8, 12, 16)
 - Support current and future caching needs for API endpoints (e.g., `/v1/messages`)
 - Ensure security, compliance, and extensibility
 - Serve as a living reference for TaskMaster Task 12 and all related caching work
@@ -15,12 +18,14 @@ This document provides a concrete, actionable, and defensive implementation plan
 ## TaskMaster Tasks & Deliverables
 
 ### **Current Tasks**
+
 - **Task 12:** Setup Node-Cache Service (TTL, invalidation, monitoring)
   - **12.1:** Implement cache storage and retrieval with TTL
   - **12.2:** Add cache invalidation and warming
   - **12.3:** Expose cache statistics and monitoring
 
 ### **Future-Proofing**
+
 - Design for easy migration to Redis or distributed cache
 - Modularize for per-endpoint and per-key strategies
 - Integrate with observability (Sentry, PostHog)
@@ -55,13 +60,17 @@ This document provides a concrete, actionable, and defensive implementation plan
 ## Implementation Phases & Phase Gates
 
 ### 1. Service Module & Basic Operations
-> **Phase Gate:** `node-cache` is installed and imported. Service exposes `get`, `set`, `del`, `stats`.
+
+> **Phase Gate:** `node-cache` is installed and imported. Service exposes `get`, `set`, `del`,
+> `stats`.
 
 **Success Criteria:**
+
 - Can store, retrieve, and delete cache entries with TTL
 - Stats method returns hit/miss counts, keys, and memory usage
 
 **Example:**
+
 ```js
 // services/cache.js
 import NodeCache from 'node-cache';
@@ -77,14 +86,18 @@ export default {
 ---
 
 ### 2. Integration with API Endpoints
-> **Phase Gate:** Cache middleware or logic is added to `/v1/messages` and other high-traffic endpoints.
+
+> **Phase Gate:** Cache middleware or logic is added to `/v1/messages` and other high-traffic
+> endpoints.
 
 **Success Criteria:**
+
 - API checks cache before DB
 - On cache hit, returns cached response
 - On miss, fetches from DB, stores in cache
 
 **Example:**
+
 ```js
 // routes/messages.js
 import cache from '../services/cache.js';
@@ -101,13 +114,17 @@ router.get('/', async (req, res) => {
 ---
 
 ### 3. Invalidation & Warming
-> **Phase Gate:** Invalidation logic is implemented for data-changing endpoints (e.g., POST/PUT/DELETE).
+
+> **Phase Gate:** Invalidation logic is implemented for data-changing endpoints (e.g.,
+> POST/PUT/DELETE).
 
 **Success Criteria:**
+
 - Cache is invalidated on relevant data changes
 - Optionally, cache is pre-warmed on startup
 
 **Example:**
+
 ```js
 // On data change
 cache.del('messages');
@@ -118,13 +135,16 @@ cache.set('messages', await fetchMessagesFromDB(), 300);
 ---
 
 ### 4. Monitoring & Observability
+
 > **Phase Gate:** Cache stats are exposed and events are logged to Sentry/PostHog.
 
 **Success Criteria:**
+
 - `/cache/stats` or `/health` returns cache metrics
 - Cache hits/misses/errors are logged
 
 **Example:**
+
 ```js
 // routes/cache.js
 router.get('/stats', (req, res) => res.json(cache.stats()));
@@ -136,9 +156,11 @@ if (error) Sentry.captureException(error);
 ---
 
 ### 5. Testing & Validation
+
 > **Phase Gate:** Vitest test suite covers all cache logic, edge cases, and error paths.
 
 **Success Criteria:**
+
 - All cache operations are tested (get, set, del, stats)
 - Edge cases: expired keys, invalidation, memory limits
 - Test logs and metrics for cache events
@@ -146,6 +168,7 @@ if (error) Sentry.captureException(error);
 ---
 
 ## Defensive Rollback & Iteration Plan
+
 - After each change, run affected and full test suite
 - If regression, revert last change and isolate issue
 - Log all findings and lessons learned in TaskMaster and docs
@@ -154,6 +177,7 @@ if (error) Sentry.captureException(error);
 ---
 
 ## Acceptance Criteria & Checklist
+
 - [ ] Service module implemented and tested
 - [ ] Integrated with at least one API endpoint
 - [ ] Invalidation and warming logic present
@@ -165,6 +189,7 @@ if (error) Sentry.captureException(error);
 ---
 
 ## References & Best Practices
+
 - PRD.md (Sections 6, 7, 8, 12, 16)
 - [CanAI Structure Rules](../.cursor/rules/canai-structure-rules.mdc)
 - [Task 9 Input Validation Plan](task-9-input-validation-middleware.md)

--- a/docs/task-15-best-practices.md
+++ b/docs/task-15-best-practices.md
@@ -5,11 +5,15 @@
 ---
 
 ## Overview
-This guide distills the proven best practices from Task 15 (POST /v1/generate-preview-spark API) into actionable patterns for API, service, and test development. It is based on real code, tests, and documentation, and is intended for quick reference and reuse across the codebase.
+
+This guide distills the proven best practices from Task 15 (POST /v1/generate-preview-spark API)
+into actionable patterns for API, service, and test development. It is based on real code, tests,
+and documentation, and is intended for quick reference and reuse across the codebase.
 
 ---
 
 ## 1. API Route & Handler Design
+
 - **Schema-Driven Validation:** Use Joi schemas in middleware for all input validation.
 - **Defensive Error Handling:**
   - Treat service errors as user input errors (400), unexpected as 500.
@@ -22,6 +26,7 @@ This guide distills the proven best practices from Task 15 (POST /v1/generate-pr
 ---
 
 ## 2. Service Layer Patterns
+
 - **Input Normalization:** Sanitize, trim, and type-check all inputs before validation.
 - **Schema Validation:** Validate normalized input with Joi, collecting all errors.
 - **Prompt Construction:** Use dedicated prompt templates for LLM calls.
@@ -31,6 +36,7 @@ This guide distills the proven best practices from Task 15 (POST /v1/generate-pr
 ---
 
 ## 3. Input Schema Design
+
 - **Explicit Field Validation:** Use Joi for types, required/optional, and constraints.
 - **Conditional Requirements:** Use `.when()` for fields with conditional logic.
 - **Pattern Reuse:** Centralize regex/value patterns in a shared module.
@@ -38,6 +44,7 @@ This guide distills the proven best practices from Task 15 (POST /v1/generate-pr
 ---
 
 ## 4. Testing Strategy
+
 - **Mock All Externals:** Use `vi.mock` at the top of test files for all dependencies.
 - **State Reset:** Use `beforeEach`/`afterEach` to reset modules and clear mocks.
 - **Comprehensive Test Cases:** Cover all valid, minimal, missing, malformed, and edge cases.
@@ -49,6 +56,7 @@ This guide distills the proven best practices from Task 15 (POST /v1/generate-pr
 ---
 
 ## 5. Prompt Engineering
+
 - **Structured, Minimal Prompts:**
   - Clear, concise instructions for LLMs.
   - Specify output format (e.g., JSON with `title` and `tagline`).
@@ -57,15 +65,20 @@ This guide distills the proven best practices from Task 15 (POST /v1/generate-pr
 ---
 
 ## 6. Documentation & Test Plan
+
 - **API Contract:** Document endpoint, input/output schema, and error structure.
-- **Test Plan Skeleton:** List input permutations, analytics, logging, mocking, edge cases, performance, and security.
-- **Defensive Implementation Plan:** Stepwise plan for incremental changes, logging, mocking, rollback, and verification.
-- **Evidence of Success:** Require logs/screenshots, analytics logs, coverage, and confirmation of mocks before merge.
+- **Test Plan Skeleton:** List input permutations, analytics, logging, mocking, edge cases,
+  performance, and security.
+- **Defensive Implementation Plan:** Stepwise plan for incremental changes, logging, mocking,
+  rollback, and verification.
+- **Evidence of Success:** Require logs/screenshots, analytics logs, coverage, and confirmation of
+  mocks before merge.
 - **Lessons Learned:** Document root causes and prevention strategies.
 
 ---
 
 ## 7. General Defensive Patterns
+
 - **Guard All Logs:** Use `NODE_ENV === 'test'` for all debug/test logs.
 - **Analytics Consistency:** Use the same analytics instance in app and tests.
 - **Rollback Plan:** Revert, isolate, and reapply changes incrementally after failures.
@@ -74,17 +87,22 @@ This guide distills the proven best practices from Task 15 (POST /v1/generate-pr
 ---
 
 ## 8. Reusable Code Snippets
+
 **Mocking Externals in Vitest:**
+
 ```js
 vi.mock('openai', () => ({
-  default: class MockOpenAI { /* ... */ }
+  default: class MockOpenAI {
+    /* ... */
+  },
 }));
 vi.mock('../supabase/client.js', () => ({
-  default: { rpc: vi.fn(), from: vi.fn() }
+  default: { rpc: vi.fn(), from: vi.fn() },
 }));
 ```
 
 **Test-Only Logging:**
+
 ```js
 if (process.env.NODE_ENV === 'test') {
   logger.info('[route] /generate-preview-spark ENTRY', req.body);
@@ -92,12 +110,14 @@ if (process.env.NODE_ENV === 'test') {
 ```
 
 **Analytics Event Assertion:**
+
 ```js
 expect(analyticsSpy).toHaveBeenCalledWith('preview_viewed', expect.any(Object));
 expect(errorAnalyticsSpy).toHaveBeenCalledWith(expect.objectContaining({ event: 'preview_error' }));
 ```
 
 **User-Friendly Error Assertion:**
+
 ```js
 expect(response.body.error).toMatch(/user-friendly/i);
 expect(response.body.stack).toBeUndefined();
@@ -106,21 +126,24 @@ expect(response.body.stack).toBeUndefined();
 ---
 
 ## 9. File-by-File Best Practices Table
-| File/Area                                 | Best Practice Highlights                                                                 |
-|-------------------------------------------|------------------------------------------------------------------------------------------|
-| `routes/generateSparks.js`                | Schema-driven validation, logging-first, analytics, defensive error handling             |
-| `services/previewGenerator.js`            | Input normalization, schema validation, orchestrator pattern, test-only logs             |
-| `schemas/generatePreviewSpark.js`         | Explicit Joi validation, custom messages, conditional requirements                       |
-| `tests/integration/generatePreviewSpark.api.test.js` | Mock all externals, reset state, analytics/logging assertions, edge case coverage        |
-| `prompts/preview_spark.js`                | Minimal, structured prompt, output format enforcement                                    |
-| `docs/task-15-Create-POST-v1-generate-preview-spark-API.md` | API contract, error structure, analytics/logging assertion patterns                      |
-| `docs/generate-preview-spark-test-plan.md`| Test plan skeleton, input permutations, analytics/logging, mocking, edge cases           |
-| `docs/task-15-defensive-implementation-plan.md` | Stepwise plan, rollback, evidence requirements, lessons learned                          |
+
+| File/Area                                                   | Best Practice Highlights                                                          |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `routes/generateSparks.js`                                  | Schema-driven validation, logging-first, analytics, defensive error handling      |
+| `services/previewGenerator.js`                              | Input normalization, schema validation, orchestrator pattern, test-only logs      |
+| `schemas/generatePreviewSpark.js`                           | Explicit Joi validation, custom messages, conditional requirements                |
+| `tests/integration/generatePreviewSpark.api.test.js`        | Mock all externals, reset state, analytics/logging assertions, edge case coverage |
+| `prompts/preview_spark.js`                                  | Minimal, structured prompt, output format enforcement                             |
+| `docs/task-15-Create-POST-v1-generate-preview-spark-API.md` | API contract, error structure, analytics/logging assertion patterns               |
+| `docs/generate-preview-spark-test-plan.md`                  | Test plan skeleton, input permutations, analytics/logging, mocking, edge cases    |
+| `docs/task-15-defensive-implementation-plan.md`             | Stepwise plan, rollback, evidence requirements, lessons learned                   |
 
 ---
 
 ## 10. Who Should Use This Guide?
+
 **Directly applicable to:**
+
 - Task 13: GET /v1/messages API
 - Task 18: POST /v1/validate-input API
 - Task 22: POST /v1/intent-mirror API
@@ -133,6 +156,7 @@ expect(response.body.stack).toBeUndefined();
 ---
 
 ## 11. References
+
 - [Task 15 API Contract](task-15-Create-POST-v1-generate-preview-spark-API.md)
 - [Task 15 Test Plan](generate-preview-spark-test-plan.md)
 - [Task 15 Defensive Implementation Plan](task-15-defensive-implementation-plan.md)


### PR DESCRIPTION
convert module.exports to export default for esm mode.

ensures runtime compatibility with 'type: module'.

no logic changes.

all tests pass.

related: render deployment esm/cjs interop issue.

task 15 defensive refactor.